### PR TITLE
Corrects relative height/width in rotated ellipses

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Ellipse.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Ellipse.cs
@@ -95,4 +95,23 @@ public class Ellipse
             plt.SetAxisLimits(-10, 10, -10, 10);
         }
     }
+
+    public class EllipseRotation: IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Ellipse();
+        public string ID => "ellipse_rotation";
+        public string Title => "Ellipse Rotation";
+        public string Description => "Ellipses can also be rotated";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            for(int i = 0; i < 5; i++)
+            {
+                var el = plt.AddEllipse(i * 10, 0, 3, 15);
+                el.Rotation = i * 15;
+            }
+
+            //plt.AxisScaleLock(true);
+        }
+    }
 }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Ellipse.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Ellipse.cs
@@ -111,7 +111,7 @@ public class Ellipse
                 el.Rotation = i * 15;
             }
 
-            //plt.AxisScaleLock(true);
+            plt.AxisScaleLock(true);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/Ellipse.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Ellipse.cs
@@ -29,7 +29,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Rotation of the ellipse (degrees)
         /// </summary>
-        public double Rotation { get; set; } = 0;
+        public float Rotation { get; set; } = 0;
 
         /// <summary>
         /// Outline color
@@ -131,18 +131,27 @@ namespace ScottPlot.Plottable
             float yRadiusPixels = dims.GetPixelY(Y + RadiusY) - yPixel;
 
             gfx.TranslateTransform(xPixel, yPixel);
-            gfx.RotateTransform((float)Rotation);
-            gfx.TranslateTransform(-xPixel, -yPixel);
-            
+            gfx.RotateTransform(Rotation);
+
+            double rotationRads = Rotation * Math.PI / 180;
+            float xScale = (float)(xRadiusPixels * Math.Cos(rotationRads) + yRadiusPixels * Math.Sin(rotationRads));
+            float yScale = (float)(yRadiusPixels * Math.Cos(rotationRads) + xRadiusPixels * Math.Sin(rotationRads));
+            gfx.ScaleTransform(xScale, yScale);
+
             RectangleF rect = new(
-                x: xPixel - xRadiusPixels,
-                y: yPixel - yRadiusPixels,
-                width: xRadiusPixels * 2,
-                height: yRadiusPixels * 2);
+                x: -1,
+                y: -1f,
+                width: 2,
+                height: 2);
 
             // Render data by drawing on the Graphics object
             if (Color != Color.Transparent)
                 gfx.FillEllipse(brush, rect);
+
+            // Otherwise the pen width will be scaled as well
+            using System.Drawing.Drawing2D.Matrix invertScaleMatrix = new();
+            invertScaleMatrix.Scale(1 / xScale, 1 / yScale);
+            pen.Transform = invertScaleMatrix;
 
             gfx.DrawEllipse(pen, rect);
         }

--- a/src/ScottPlot4/ScottPlot/Plottable/Ellipse.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Ellipse.cs
@@ -134,9 +134,7 @@ namespace ScottPlot.Plottable
             gfx.RotateTransform(Rotation);
 
             double rotationRads = Rotation * Math.PI / 180;
-            float xScale = (float)(xRadiusPixels * Math.Cos(rotationRads) + yRadiusPixels * Math.Sin(rotationRads));
-            float yScale = (float)(yRadiusPixels * Math.Cos(rotationRads) + xRadiusPixels * Math.Sin(rotationRads));
-            gfx.ScaleTransform(xScale, yScale);
+            gfx.ScaleTransform(xRadiusPixels, yRadiusPixels);
 
             RectangleF rect = new(
                 x: -1,
@@ -150,7 +148,7 @@ namespace ScottPlot.Plottable
 
             // Otherwise the pen width will be scaled as well
             using System.Drawing.Drawing2D.Matrix invertScaleMatrix = new();
-            invertScaleMatrix.Scale(1 / xScale, 1 / yScale);
+            invertScaleMatrix.Scale(1 / xRadiusPixels, 1 / yRadiusPixels);
             pen.Transform = invertScaleMatrix;
 
             gfx.DrawEllipse(pen, rect);


### PR DESCRIPTION
This also adds a demo of rotated ellipses:
![image](https://user-images.githubusercontent.com/8635304/232181911-09e77f42-a4c8-45d1-ac37-9379ad2c835b.png)
